### PR TITLE
Fix comment for GPT-4o cost

### DIFF
--- a/textract_ssml_processor/utils.py
+++ b/textract_ssml_processor/utils.py
@@ -534,7 +534,7 @@ def estimate_cost(file_path):
     
     character_count = len(text)
 
-    # OpenAI gpt-4oo cost
+    # OpenAI gpt-4o cost
     gpt_cost = (character_count / 1000000) * 20  # $0.02 per 1k tokens (approx 750 characters)
 
     # Amazon Polly costs


### PR DESCRIPTION
## Summary
- correct GPT-4o comment in `utils.py`

## Testing
- `pytest -q` *(fails: command not found)*