### PR TITLE
Remove unused title/author inputs

### DIFF
--- a/textract_ssml_processor/app.py
+++ b/textract_ssml_processor/app.py
@@ -35,11 +35,9 @@ def index():
     upload_form = UploadForm()
     if request.method == 'POST' and upload_form.validate_on_submit():
         files = request.files.getlist('files')
-        title = upload_form.title.data
-        author = upload_form.author.data
         language = upload_form.language.data
-        
-        logger.info(f"Received upload request: Title: {title}, Author: {author}, Language: {language}")
+
+        logger.info(f"Received upload request: Language: {language}")
         
         # Save files temporarily and get their paths
         file_paths = []
@@ -62,8 +60,6 @@ def index():
                                polly_cost_generative=f"${polly_cost_generative:.2f}",
                                polly_cost_long_form=f"${polly_cost_long_form:.2f}",
                                files=file_paths,
-                               title=title,
-                               author=author,
                                language=language)
     
     processed_files = get_existing_files(current_app.config['PROCESSED_FOLDER'])
@@ -76,11 +72,9 @@ def confirm():
     logger.info("Confirm route accessed")
     try:
         files = request.form.getlist('files')
-        title = request.form.get('title')
-        author = request.form.get('author')
         language = request.form.get('language')
-        
-        logger.info(f"Received data: files={files}, title={title}, author={author}, language={language}")
+
+        logger.info(f"Received data: files={files}, language={language}")
         
         if not files:
             logger.error("No files received in the request")
@@ -92,7 +86,7 @@ def confirm():
             logger.info(f"Processing file: {file_path}")
             if os.path.exists(file_path):
                 try:
-                    output_json_path = handle_uploaded_file(file_path, title, author, language)
+                    output_json_path = handle_uploaded_file(file_path, language)
                     processed_files.append(os.path.basename(output_json_path))
                     logger.info(f"File processed successfully: {output_json_path}")
                     os.remove(file_path)  # Remove the temporary file

--- a/textract_ssml_processor/forms.py
+++ b/textract_ssml_processor/forms.py
@@ -4,8 +4,6 @@ from wtforms import StringField, FileField, SubmitField
 from wtforms.validators import DataRequired
 
 class UploadForm(FlaskForm):
-    title = StringField('Title', validators=[DataRequired()])
-    author = StringField('Author', validators=[DataRequired()])
     language = StringField('Language', validators=[DataRequired()])
     files = FileField('Files', validators=[DataRequired()], render_kw={'multiple': True})
     submit = SubmitField('Upload')

--- a/textract_ssml_processor/templates/confirm.html
+++ b/textract_ssml_processor/templates/confirm.html
@@ -27,8 +27,6 @@
             {% for file in files %}
             <input type="hidden" name="files" value="{{ file }}">
             {% endfor %}
-            <input type="hidden" name="title" value="{{ title }}">
-            <input type="hidden" name="author" value="{{ author }}">
             <input type="hidden" name="language" value="{{ language }}">
             <button type="submit" class="btn btn-primary">Confirm and Process</button>
         </form>

--- a/textract_ssml_processor/templates/index.html
+++ b/textract_ssml_processor/templates/index.html
@@ -33,12 +33,6 @@
                 {{ upload_form.files.label }} {{ upload_form.files(class="form-control-file", multiple=True) }}
             </div>
             <div class="form-group">
-                {{ upload_form.title.label }} {{ upload_form.title(class="form-control") }}
-            </div>
-            <div class="form-group">
-                {{ upload_form.author.label }} {{ upload_form.author(class="form-control") }}
-            </div>
-            <div class="form-group">
                 {{ upload_form.language.label }} {{ upload_form.language(class="form-control") }}
             </div>
             {{ upload_form.submit(class="btn btn-primary") }}

--- a/textract_ssml_processor/utils.py
+++ b/textract_ssml_processor/utils.py
@@ -93,7 +93,7 @@ def chunk_text(text: str, max_chunk_size: int = 2000) -> List[str]:
 #     return [f"<speak>{chunk}</speak>" for chunk in ssml_chunks]
 
 # Function to generate SSML request
-def generate_ssml_request(text_chunk, title, author):
+def generate_ssml_request(text_chunk):
     allowed_tags = "<break>, <lang>, <p>, <phoneme>, <s>, <speak>, <sub>, <w>"
     prompt_text = (f"Please review this messy text to format, correct any spelling mistakes, remove page numbers and page titles, and mark it up with SSML markup for a text-to-speech process. "
                    f"The only permitted tags are {allowed_tags}. Please only provide the marked up text in your response. "
@@ -188,7 +188,7 @@ def safe_format_text_with_gpt(text_chunk: str, language: str) -> Tuple[str, str]
     if language.lower() != 'english':
         formatted_prompt = generate_translation_request(text_chunk, language)
     else:
-        formatted_prompt = generate_ssml_request(text_chunk, "", "")
+        formatted_prompt = generate_ssml_request(text_chunk)
 
     for attempt in range(5):  # Retry up to 5 times
         try:
@@ -219,12 +219,12 @@ def safe_format_text_with_gpt(text_chunk: str, language: str) -> Tuple[str, str]
             time.sleep(wait)
     raise Exception("Failed to process text after multiple attempts")
 
-def handle_uploaded_file(file_path: str, title: str, author: str, language: str) -> str:
+def handle_uploaded_file(file_path: str, language: str) -> str:
     filename = os.path.basename(file_path)
     output_file_name = f"processed_{filename}"
     
     # Process the file
-    output_dict = process_text_file(file_path, output_file_name, title, author, language)
+    output_dict = process_text_file(file_path, output_file_name, language)
     
     # Save the output dictionary as a JSON file
     output_json_path = os.path.join(current_app.config['PROCESSED_FOLDER'], f"{output_file_name}.json")
@@ -287,7 +287,7 @@ import time
 from typing import Dict, List
 from functools import partial
 
-def process_text_file(file_path: str, output_file_name: str, title: str, author: str, language: str) -> Dict[str, List[Dict[str, str]]]:
+def process_text_file(file_path: str, output_file_name: str, language: str) -> Dict[str, List[Dict[str, str]]]:
     logger.info(f"Starting to process file: {file_path}")
     
     with open(file_path, 'r', encoding='utf-8') as file:


### PR DESCRIPTION
## Summary
- simplify translation upload form
- drop unused title and author fields
- update translation handling functions accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`