### PR TITLE
Ensure app directories exist on startup

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,12 +1,19 @@
 import os
 
+from config import Config
+
 def create_directories():
-    # Get the directory of the current script
-    base_dir = os.path.dirname(os.path.abspath(__file__))
-    
-    directories = ["processed", "chunks", "uploads"]
-    for directory in directories:
-        path = os.path.join(base_dir, directory)
+    """Ensure application data folders exist."""
+    directories = [
+        Config.PROCESSED_FOLDER,
+        Config.CHUNKS_FOLDER,
+        Config.UPLOAD_FOLDER,
+        Config.LATIN_FOLDER,
+        Config.AUDIO_OUTPUT_FOLDER,
+        Config.SUBTITLE_OUTPUT,
+    ]
+
+    for path in directories:
         if not os.path.exists(path):
             os.makedirs(path)
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import types
+import importlib.util
+import importlib.machinery
+from pathlib import Path
+
+
+def load_run_module(tmp_path):
+    config = types.SimpleNamespace(
+        PROCESSED_FOLDER=str(tmp_path / "processed"),
+        CHUNKS_FOLDER=str(tmp_path / "chunks"),
+        UPLOAD_FOLDER=str(tmp_path / "uploads"),
+        LATIN_FOLDER=str(tmp_path / "latin"),
+        AUDIO_OUTPUT_FOLDER=str(tmp_path / "audio"),
+        SUBTITLE_OUTPUT=str(tmp_path / "subtitles"),
+    )
+    sys.modules['config'] = types.SimpleNamespace(Config=config)
+    sys.modules['textract_ssml_processor'] = types.SimpleNamespace(create_app=lambda: None)
+
+    path = Path(__file__).resolve().parents[1] / 'run.py'
+    loader = importlib.machinery.SourceFileLoader('run_module', str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module, config
+
+
+def test_create_directories(tmp_path):
+    run_mod, cfg = load_run_module(tmp_path)
+    run_mod.create_directories()
+    for d in [
+        cfg.PROCESSED_FOLDER,
+        cfg.CHUNKS_FOLDER,
+        cfg.UPLOAD_FOLDER,
+        cfg.LATIN_FOLDER,
+        cfg.AUDIO_OUTPUT_FOLDER,
+        cfg.SUBTITLE_OUTPUT,
+    ]:
+        assert os.path.isdir(d)


### PR DESCRIPTION
## Summary
- make `run.create_directories` create folders from `Config`
- add regression test for directory creation

## Testing
- `pytest -q` *(fails: command not found)*