### PR TITLE
Remove patrologia_latina.db from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ translation_logs/
 subtitles/
 latin/
 app.log*
+patrologia_latina.db


### PR DESCRIPTION
## Summary
- remove `patrologia_latina.db` from version control
- ignore `patrologia_latina.db` in `.gitignore`

## Testing
- `pytest -q` *(fails: command not found)*