### PR TITLE
Add progress bar on confirm page

### DIFF
--- a/textract_ssml_processor/templates/confirm.html
+++ b/textract_ssml_processor/templates/confirm.html
@@ -18,18 +18,31 @@
             {% endfor %}
         </ul>
 
-        <form method="POST" action="{{ url_for('app.confirm') }}">
+        <form method="POST" action="{{ url_for('app.confirm') }}" id="confirm-form">
             {% for file in files %}
             <input type="hidden" name="files" value="{{ file }}">
             {% endfor %}
             <input type="hidden" name="language" value="{{ language }}">
-            <button type="submit" class="btn btn-primary">Confirm and Process</button>
+            <button type="submit" class="btn btn-primary" id="confirm-button" onclick="showLoading()">Confirm and Process</button>
         </form>
         <a href="{{ url_for('app.index') }}" class="btn btn-secondary mt-2">Cancel</a>
+
+        <div id="loading" class="mt-3" style="display: none;">
+            <div class="progress">
+                <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 100%"></div>
+            </div>
+            <p class="mt-2">Processing, please wait...</p>
+        </div>
     </div>
 {% endblock %}
 {% block scripts %}
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
+    <script>
+        function showLoading() {
+            document.getElementById('loading').style.display = 'block';
+            document.getElementById('confirm-button').disabled = true;
+        }
+    </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show a progress indicator when processing starts

## Testing
- `pytest -q` *(fails: command not found)*